### PR TITLE
Fix path with spaces on Windows

### DIFF
--- a/git-forward-merge.sh
+++ b/git-forward-merge.sh
@@ -51,7 +51,7 @@ USAGE="list [<options>]
     or: $dashless <source_branch> <destination_branch>
     or: $dashless <destination_branch>"
 
-. $(git --exec-path)/git-sh-setup
+. "$(git --exec-path)/git-sh-setup"
 
 currentbranch=$(git rev-parse --abbrev-ref HEAD)
 


### PR DESCRIPTION
The script fails with error `C:\Program Files\Git\mingw64/libexec/git-core\git-forward-merge: line 54: C:\Program: No such file or directory` on Windows if the Git installation path (`git --exec-path`) contains spaces.

On WIndows, Git 2.7+ installs to `C:\Program Files\Git\mingw64\libexec\git-core` by default. Git 2.6 for example installs to `C:\Users\Calin\AppData\Local\Programs\Git\mingw64\libexec\git-core`, so the problem doesn't exist on this version of Git.
